### PR TITLE
Fix datetime/timedelta bug

### DIFF
--- a/test/test_metrics_analyzer.py
+++ b/test/test_metrics_analyzer.py
@@ -1,5 +1,6 @@
 import math
 import unittest
+from datetime import timedelta
 
 from whisper_automatic_test.exceptions.invalid_timestamp_exception import InvalidTimestampException
 from whisper_automatic_test.exceptions.no_requests_exception import NoRequestsException
@@ -29,24 +30,24 @@ class TestMetricsAnalyzer(unittest.TestCase):
             get_suggestions(EXAMPLE_WHISPER_RESPONSE_QUESTIONS_FILE_PATH)
         )
         suggestions_responses = [
-            SuggestionsResponse(self._suggestions_3_questions, 42, 91),
-            SuggestionsResponse(self._suggestions_3_links, 42, 91),
-            SuggestionsResponse(self._suggestions_3_questions, 42, 96),
-            SuggestionsResponse(self._suggestions_3_questions, 42, 90),
-            SuggestionsResponse(self._suggestions_3_questions, 42, 90),
-            SuggestionsResponse(self._suggestions_3_links, 42, 90),
-            SuggestionsResponse(self._suggestions_3_links, 42, 90),
+            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=49)),
+            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=49)),
+            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=54)),
+            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
         ]
         self._scenarios = get_scenarios_from_csv_file(SCENARIO_FILE_PATH)
         self._metrics_analyzer = MetricsAnalyzer(self._scenarios, suggestions_responses)
         empty_suggestions_suggestions_responses = [
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42)
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0))
         ]
         self._no_suggestions_responses_metrics_analyzer = \
             MetricsAnalyzer(self._scenarios, empty_suggestions_suggestions_responses)
@@ -55,7 +56,7 @@ class TestMetricsAnalyzer(unittest.TestCase):
 
     def test_constructor_with_no_request_in_scenarios(self):
         with self.assertRaises(NoRequestsException):
-            MetricsAnalyzer([Scenario([])], [SuggestionsResponse([], 10, 20)])
+            MetricsAnalyzer([Scenario([])], [SuggestionsResponse([], timedelta(seconds=10))])
 
     def test_constructor_with_no_suggestions_responses(self):
         with self.assertRaises(NoSuggestionsResponsesException):
@@ -63,26 +64,31 @@ class TestMetricsAnalyzer(unittest.TestCase):
 
     def test_constructor_with_invalid_response_timestamp(self):
         invalid_timestamp_suggestions_responses = [
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 666, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42),
-            SuggestionsResponse([], 42, 42)
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=-666)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0)),
+            SuggestionsResponse([], timedelta(seconds=0))
         ]
         with self.assertRaises(InvalidTimestampException):
             MetricsAnalyzer(self._scenarios, invalid_timestamp_suggestions_responses)
 
     def test_constructor_with_no_suggestions_response_for_every_request(self):
         with self.assertRaises(NoSuggestionsResponsesForEveryRequestsException):
-            MetricsAnalyzer(self._scenarios, [SuggestionsResponse([], 10, 20)])
+            MetricsAnalyzer(self._scenarios, [SuggestionsResponse([], timedelta(seconds=10))])
 
     def test_average_system_response_time(self):
-        self.assertAlmostEquals(49.143, self._metrics_analyzer.calculate_average_system_response_time(), places=3)
+        actual = self._metrics_analyzer.calculate_average_system_response_time()
+        expected = timedelta(seconds=49.143)
+        self.assertAlmostEquals(expected, actual, delta=timedelta(seconds=0.001))
 
     def test_average_system_response_time_with_immediate_response(self):
-        self.assertAlmostEquals(0, self._immediate_response_metrics_analyzer.calculate_average_system_response_time())
+        self.assertAlmostEquals(
+            timedelta(seconds=0),
+            self._immediate_response_metrics_analyzer.calculate_average_system_response_time()
+        )
 
     def test_messages_number(self):
         self.assertEquals(7, self._metrics_analyzer.calculate_messages_number())
@@ -131,13 +137,13 @@ class TestMetricsAnalyzer(unittest.TestCase):
 
     def test_number_of_suggested_questions_when_not_all_questions_updated(self):
         suggestions_responses = [
-            SuggestionsResponse(self._suggestions_3_links, 42, 91),
-            SuggestionsResponse(self._suggestions_3_questions, 42, 91),
-            SuggestionsResponse(self._suggestions_3_links, 42, 96),
-            SuggestionsResponse(self._suggestions_3_links, 42, 90),
-            SuggestionsResponse(self._suggestions_3_links, 42, 90),
-            SuggestionsResponse(self._suggestions_3_questions, 42, 90),
-            SuggestionsResponse(self._suggestions_3_questions, 42, 90),
+            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=49)),
+            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=49)),
+            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=54)),
+            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
         ]
         metrics_analyzer = MetricsAnalyzer(self._scenarios, suggestions_responses)
         self.assertEquals(6, metrics_analyzer.calculate_number_of_suggested_questions())

--- a/test/test_quality_indexes_analyzer.py
+++ b/test/test_quality_indexes_analyzer.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import timedelta
 from unittest.mock import Mock
 
 from whisper_automatic_test.quality_indexes_analyzer import QualityIndexesAnalyzer
@@ -12,7 +13,7 @@ class TestQualityIndexesAnalyzer(unittest.TestCase):
         self._mock_metrics_analyzer = Mock()
         self._quality_indexes_analyzer = QualityIndexesAnalyzer(self._mock_metrics_analyzer)
 
-        self._mock_metrics_analyzer.calculate_average_system_response_time.return_value = 10
+        self._mock_metrics_analyzer.calculate_average_system_response_time.return_value = timedelta(seconds=10)
         self._mock_metrics_analyzer.calculate_messages_number.return_value = 11
         self._mock_metrics_analyzer.calculate_mean_position_of_chosen_suggestions.return_value = 12
         self._mock_metrics_analyzer.calculate_total_number_of_suggestions_updates.return_value = 13

--- a/test/test_scenarios_runner.py
+++ b/test/test_scenarios_runner.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import timedelta, datetime
 from unittest.mock import Mock
 
 from whisper_automatic_test.request import Request
@@ -32,35 +33,43 @@ class TestScenariosRunner(unittest.TestCase):
         ]
 
         self._mock_get_time = Mock()
-        self._mock_get_time.side_effect = [11, 22, 33, 44, 55, 66]
+        self._mock_get_time.side_effect = [
+            datetime(2005, 12, 30, 6, 45, 1),
+            datetime(2005, 12, 30, 6, 45, 2),
+            datetime(2005, 12, 30, 6, 45, 4),
+            datetime(2005, 12, 30, 6, 45, 7),
+            datetime(2005, 12, 30, 6, 45, 11),
+            datetime(2005, 12, 30, 6, 45, 16)
+        ]
 
         self._scenario_runner = ScenariosRunner(self._mock_get_suggestions, self._mock_get_time)
 
     def test_run_scenarios(self):
         suggestions_responses = self._scenario_runner.run(self._scenarios)
         self.assertEquals(3, len(suggestions_responses))
-        suggestions_a = suggestions_responses[0].get_suggestions()
+        suggestions_reponse_a = suggestions_responses[0]
+        suggestions_reponse_b = suggestions_responses[1]
+        suggestions_reponse_c = suggestions_responses[2]
+
+        suggestions_a = suggestions_reponse_a.get_suggestions()
         self.assertEquals(2, len(suggestions_a))
         self.assertEquals('link', suggestions_a[0].get_type())
         self.assertEquals('some_url', suggestions_a[0].get_data())
         self.assertEquals('link', suggestions_a[1].get_type())
         self.assertEquals('another_url', suggestions_a[1].get_data())
-        self.assertEquals(11, suggestions_responses[0].get_timestamp_sent_request())
-        self.assertEquals(22, suggestions_responses[0].get_timestamp_received_response())
+        self.assertEquals(timedelta(seconds=1), suggestions_reponse_a.get_response_time_duration())
 
-        suggestions_b = suggestions_responses[1].get_suggestions()
+        suggestions_b = suggestions_reponse_b.get_suggestions()
         self.assertEquals(1, len(suggestions_b))
         self.assertEquals('link', suggestions_b[0].get_type())
         self.assertEquals('url_of_a_different_suggestions_response', suggestions_b[0].get_data())
-        self.assertEquals(33, suggestions_responses[1].get_timestamp_sent_request())
-        self.assertEquals(44, suggestions_responses[1].get_timestamp_received_response())
+        self.assertEquals(timedelta(seconds=3), suggestions_reponse_b.get_response_time_duration())
 
-        suggestions_c = suggestions_responses[2].get_suggestions()
+        suggestions_c = suggestions_reponse_c.get_suggestions()
         self.assertEquals(1, len(suggestions_c))
         self.assertEquals('link', suggestions_c[0].get_type())
         self.assertEquals('some_url_of_suggestion_scenario_2', suggestions_c[0].get_data())
-        self.assertEquals(55, suggestions_responses[2].get_timestamp_sent_request())
-        self.assertEquals(66, suggestions_responses[2].get_timestamp_received_response())
+        self.assertEquals(timedelta(seconds=5), suggestions_reponse_c.get_response_time_duration())
 
     def test_run_each_scenario_with_unique_chatkey(self):
         self._scenario_runner.run(self._scenarios)

--- a/test/test_suggestions_response.py
+++ b/test/test_suggestions_response.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import timedelta
 
 from whisper_automatic_test.suggestion import Suggestion
 from whisper_automatic_test.suggestions_response import SuggestionsResponse
@@ -10,11 +11,10 @@ class TestSuggestionsResponse(unittest.TestCase):
             Suggestion('link', 'some_url'),
             Suggestion('link', 'another_url')
         ]
-        suggestions_response = SuggestionsResponse(suggestions, 42, 90)
+        suggestions_response = SuggestionsResponse(suggestions, timedelta(seconds=42))
         self.assertEquals('link', suggestions_response.get_suggestions()[0].get_type())
         self.assertEquals('some_url', suggestions_response.get_suggestions()[0].get_data())
         self.assertEquals('link', suggestions_response.get_suggestions()[1].get_type())
         self.assertEquals('another_url', suggestions_response.get_suggestions()[1].get_data())
-        self.assertEquals(42, suggestions_response.get_timestamp_sent_request())
-        self.assertEquals(90, suggestions_response.get_timestamp_received_response())
+        self.assertEquals(timedelta(seconds=42), suggestions_response.get_response_time_duration())
 

--- a/test/test_suggestions_responses_analyzer.py
+++ b/test/test_suggestions_responses_analyzer.py
@@ -1,8 +1,10 @@
 import unittest
+from datetime import timedelta
 
 from whisper_automatic_test.exceptions.no_requests_exception import NoRequestsException
 from whisper_automatic_test.exceptions.no_suggestions_responses_exception import NoSuggestionsResponsesException
-from whisper_automatic_test.exceptions.no_suggestions_responses_for_every_requests_exception import NoSuggestionsResponsesForEveryRequestsException
+from whisper_automatic_test.exceptions.no_suggestions_responses_for_every_requests_exception \
+    import NoSuggestionsResponsesForEveryRequestsException
 from whisper_automatic_test.request import Request
 from whisper_automatic_test.scenario import Scenario
 from whisper_automatic_test.scenario_reader import get_scenarios_from_csv_file
@@ -29,24 +31,24 @@ class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
             get_suggestions(EXAMPLE_WHISPER_RESPONSE_QUESTIONS_FILE_PATH)
         )
         self._suggestions_responses = [
-            SuggestionsResponse(suggestions_3_questions, 42, 91),
-            SuggestionsResponse(suggestions_3_links, 42, 91),
-            SuggestionsResponse(suggestions_3_links, 42, 91),
-            SuggestionsResponse(suggestions_3_links, 42, 91),
-            SuggestionsResponse(suggestions_3_questions, 42, 96),
-            SuggestionsResponse(suggestions_3_questions, 42, 90),
-            SuggestionsResponse(suggestions_3_links, 42, 90),
-            SuggestionsResponse(suggestions_3_links, 42, 90),
-            SuggestionsResponse(suggestions_3_questions, 42, 90),
-            SuggestionsResponse(suggestions_3_questions, 42, 90),
-            SuggestionsResponse(suggestions_3_links, 42, 90),
-            SuggestionsResponse(suggestions_3_links, 42, 90),
-            SuggestionsResponse(suggestions_3_questions, 42, 90),
-            SuggestionsResponse(suggestions_3_questions, 42, 90),
-            SuggestionsResponse(suggestions_3_questions, 42, 90),
-            SuggestionsResponse(suggestions_3_links, 42, 90),
-            SuggestionsResponse(suggestions_3_links, 42, 90),
-            SuggestionsResponse(suggestions_3_questions, 42, 90),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=49)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=54)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
         ]
 
     def test_constructor_with_no_request_in_scenarios(self):
@@ -59,17 +61,38 @@ class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
 
     def test_constructor_with_no_suggestions_response_for_every_request(self):
         with self.assertRaises(NoSuggestionsResponsesForEveryRequestsException):
-            SuggestionsResponsesAnalyzer(self._scenarios, [SuggestionsResponse([], 10, 20)])
+            SuggestionsResponsesAnalyzer(self._scenarios, [SuggestionsResponse([], timedelta(seconds=10))])
 
     def test_analyze_with_one_successful_suggestions_response(self):
         expected_analysis = ['success']
         request = Request('asker', 'What is Coveo?', 'link', 'https://www.coveo.com/')
         suggestion = Suggestion('link', 'https://www.coveo.com/')
-        suggestions_responses_analyzer = SuggestionsResponsesAnalyzer([Scenario([request])], [SuggestionsResponse([suggestion], 0, 0)])
+        suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(
+            [Scenario([request])],
+            [SuggestionsResponse([suggestion], timedelta(seconds=0))])
         self.assertEquals(expected_analysis, suggestions_responses_analyzer.analyze())
 
     def test_analyze(self):
-        expected_analysis = ['fail', 'success', 'success', 'success', 'fail', 'fail', 'fail', 'fail', 'success', 'success', 'fail', 'fail', 'fail', 'fail', 'success', 'fail', 'success', 'fail']
+        expected_analysis = [
+            'fail',
+            'success',
+            'success',
+            'success',
+            'fail',
+            'fail',
+            'fail',
+            'fail',
+            'success',
+            'success',
+            'fail',
+            'fail',
+            'fail',
+            'fail',
+            'success',
+            'fail',
+            'success',
+            'fail'
+        ]
         suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(self._scenarios, self._suggestions_responses)
         self.assertEquals(expected_analysis, suggestions_responses_analyzer.analyze())
 
@@ -77,11 +100,19 @@ class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
         suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(self._scenarios, self._suggestions_responses)
         expected_analysis_string = \
             ('1,agent,I love mushrooms,same,,fail\n'
-             '2,asker,I have problems calling the rest API,link,https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ https://second_url.com/second_url,success\n'
-             '2,asker,I have problems calling the rest API,link,https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ https://second_url.com/second_url,success\n'
+             '2,asker,I have problems calling the rest API,link,'
+             'https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ '
+             'https://second_url.com/second_url,success\n'
+             '2,asker,I have problems calling the rest API,link,'
+             'https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ '
+             'https://second_url.com/second_url,success\n'
              '2,agent,I love mushrooms,same,,success\n'
-             '2,asker,I have problems calling the rest API,link,https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ https://second_url.com/second_url,fail\n'
-             '2,asker,I have problems calling the rest API,link,https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ https://second_url.com/second_url,fail\n'
+             '2,asker,I have problems calling the rest API,link,'
+             'https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ '
+             'https://second_url.com/second_url,fail\n'
+             '2,asker,I have problems calling the rest API,link,'
+             'https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/ '
+             'https://second_url.com/second_url,fail\n'
              '2,agent,World,link,https://asdasd.com/asdasd,fail\n'
              '2,agent,World,link,https://asdasd.com/asdasd,fail\n'
              '3,asker,Hello,question,Did you try this?,success\n'

--- a/whisper_automatic_test/metrics_analyzer.py
+++ b/whisper_automatic_test/metrics_analyzer.py
@@ -30,9 +30,7 @@ class MetricsAnalyzer:
 
     def raise_if_there_is_an_invalid_timestamp(self):
         for suggestions_response in self._suggestions_responses:
-            timestamp_after = suggestions_response.get_timestamp_received_response()
-            timestamp_before = suggestions_response.get_timestamp_sent_request()
-            is_valid_timestamp = timestamp_after >= timestamp_before
+            is_valid_timestamp = suggestions_response.get_response_time_duration() >= timedelta(seconds=0)
             if not is_valid_timestamp:
                 raise InvalidTimestampException(
                     'Received timestamp of response should not be smaller than sent timestamp')
@@ -43,10 +41,9 @@ class MetricsAnalyzer:
                 'There is not a suggestions response for every request')
 
     def calculate_average_system_response_time(self):
-        sum_of_system_response_time = timedelta(0)
+        sum_of_system_response_time = timedelta(seconds=0)
         for suggestions_response in self._suggestions_responses:
-            sum_of_system_response_time += suggestions_response.get_timestamp_received_response() - \
-                                           suggestions_response.get_timestamp_sent_request()
+            sum_of_system_response_time += suggestions_response.get_response_time_duration()
         return sum_of_system_response_time / len(self._suggestions_responses)
 
     def calculate_messages_number(self):

--- a/whisper_automatic_test/quality_indexes_analyzer.py
+++ b/whisper_automatic_test/quality_indexes_analyzer.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-TARGET_RESPONSE_TIME_SECONDS = timedelta(3.0)
+TARGET_RESPONSE_TIME_SECONDS = timedelta(seconds=3)
 
 
 class QualityIndexesAnalyzer:

--- a/whisper_automatic_test/scenarios_runner.py
+++ b/whisper_automatic_test/scenarios_runner.py
@@ -21,10 +21,10 @@ class ScenariosRunner:
         return suggestions_responses_independent_of_the_scenario
 
     def _get_suggestions_response_of_request(self, request, chatkey):
-        before_timestamp = self._get_time()
+        before_datetime = self._get_time()
         suggestions = self._get_suggestions(request, chatkey)
-        after_timestamp = self._get_time()
-        return SuggestionsResponse(suggestions, before_timestamp, after_timestamp)
+        after_datetime = self._get_time()
+        return SuggestionsResponse(suggestions, after_datetime - before_datetime)
 
     def _get_suggestions_responses_of_scenario(self, scenario, chatkey):
         return [self._get_suggestions_response_of_request(request, chatkey) for request in scenario.get_requests()]

--- a/whisper_automatic_test/suggestions_response.py
+++ b/whisper_automatic_test/suggestions_response.py
@@ -1,20 +1,13 @@
 class SuggestionsResponse:
     _suggestions = None
-    _timestamp_sent_request = None
-    _timestamp_received_response = None
+    _response_time_duration = None
 
-    def __init__(self, suggestions, timestamp_sent_request, timestamp_received_response):
+    def __init__(self, suggestions, response_time_duration):
         self._suggestions = suggestions
-        self._timestamp_sent_request = timestamp_sent_request
-        self._timestamp_received_response = timestamp_received_response
+        self._response_time_duration = response_time_duration
 
     def get_suggestions(self):
         return self._suggestions
 
-    def get_timestamp_sent_request(self):
-        return self._timestamp_sent_request
-
-    def get_timestamp_received_response(self):
-        return self._timestamp_received_response
-
-
+    def get_response_time_duration(self):
+        return self._response_time_duration

--- a/whisper_automatic_test/suggestions_responses_analyzer.py
+++ b/whisper_automatic_test/suggestions_responses_analyzer.py
@@ -1,6 +1,7 @@
 from whisper_automatic_test.exceptions.no_requests_exception import NoRequestsException
 from whisper_automatic_test.exceptions.no_suggestions_responses_exception import NoSuggestionsResponsesException
-from whisper_automatic_test.exceptions.no_suggestions_responses_for_every_requests_exception import NoSuggestionsResponsesForEveryRequestsException
+from whisper_automatic_test.exceptions.no_suggestions_responses_for_every_requests_exception \
+    import NoSuggestionsResponsesForEveryRequestsException
 
 
 def get_selected_suggestion(suggestions, data_to_find_in_suggestions):
@@ -79,8 +80,8 @@ class SuggestionsResponsesAnalyzer:
         for i, request in enumerate(self._requests):
             current_suggestions_responses = self._suggestions_responses[i].get_suggestions()
             is_success = analyse_same(request, current_suggestions_responses, previous_suggestions_responses)
-            is_success = is_success or analyse_link_or_question_with_request_data(request, current_suggestions_responses)
-            is_success = is_success or analyse_link_or_question_without_request_data(request, current_suggestions_responses)
+            is_success |= analyse_link_or_question_with_request_data(request, current_suggestions_responses)
+            is_success |= analyse_link_or_question_without_request_data(request, current_suggestions_responses)
             analysis.append('success') if is_success else analysis.append('fail')
             previous_suggestions_responses = current_suggestions_responses
         return analysis
@@ -92,7 +93,14 @@ class SuggestionsResponsesAnalyzer:
         for i, scenario in enumerate(self._scenarios):
             for request in scenario.get_requests():
                 scenario_id = str(i + 1)
-                analysis_string += scenario_id + ',' + request.get_person() + ',' + request.get_message() + ',' + request.get_success_condition() + ',' + request.get_raw_data() + ',' + analysis[
-                    analysis_position] + '\n'
+                elements = [
+                    scenario_id,
+                    request.get_person(),
+                    request.get_message(),
+                    request.get_success_condition(),
+                    request.get_raw_data(),
+                    analysis[analysis_position]
+                ]
+                analysis_string += ','.join(elements) + '\n'
                 analysis_position += 1
         return analysis_string


### PR DESCRIPTION
Tests failed because of incorrect use of datetime and timedelta to
calculate the request response time