### PR TITLE
Ignore suggestions of previous scenarios

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,8 +34,6 @@ def main():
     print_metrics(metrics_analyzer)
     print_quality_indexes(quality_indexes_analyzer)
 
-    pass
-
 
 def get_time():
     return datetime.datetime.utcnow()

--- a/test/resources/test_scenarios_second_scenario_starts_with_same.csv
+++ b/test/resources/test_scenarios_second_scenario_starts_with_same.csv
@@ -1,0 +1,5 @@
+Scenario,MessageType,Message,TestMethod,TestData
+1,agent,"link required, should pass",link,https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/
+2,asker,"same required, expects empty because start of scenario, should pass",same,
+2,agent,"link required, should pass",link,https://blog.coveo.com/goodbye-gsa-hello-intelligent-search-in-the-cloud/
+3,asker,"same required, expects empty because start of scenario, should fail",same,

--- a/test/test_metrics_analyzer.py
+++ b/test/test_metrics_analyzer.py
@@ -29,55 +29,67 @@ class TestMetricsAnalyzer(unittest.TestCase):
         self._suggestions_3_questions = whisper_response_to_suggestions(
             get_suggestions(EXAMPLE_WHISPER_RESPONSE_QUESTIONS_FILE_PATH)
         )
-        suggestions_responses = [
-            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=49)),
-            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=49)),
-            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=54)),
-            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
+        suggestions_responses_for_each_scenario = [
+            [
+                SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=49)),
+                SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=49))
+            ],
+            [
+                SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=54)),
+                SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48))
+            ]
         ]
         self._scenarios = get_scenarios_from_csv_file(SCENARIO_FILE_PATH)
-        self._metrics_analyzer = MetricsAnalyzer(self._scenarios, suggestions_responses)
-        empty_suggestions_suggestions_responses = [
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0))
+        self._metrics_analyzer = MetricsAnalyzer(self._scenarios, suggestions_responses_for_each_scenario)
+        empty_suggestions_suggestions_responses_for_each_scenario = [
+            [
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0))
+            ],
+            [
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0))
+            ]
         ]
         self._no_suggestions_responses_metrics_analyzer = \
-            MetricsAnalyzer(self._scenarios, empty_suggestions_suggestions_responses)
+            MetricsAnalyzer(self._scenarios, empty_suggestions_suggestions_responses_for_each_scenario)
         self._immediate_response_metrics_analyzer = \
-            MetricsAnalyzer(self._scenarios, empty_suggestions_suggestions_responses)
+            MetricsAnalyzer(self._scenarios, empty_suggestions_suggestions_responses_for_each_scenario)
 
     def test_constructor_with_no_request_in_scenarios(self):
         with self.assertRaises(NoRequestsException):
-            MetricsAnalyzer([Scenario([])], [SuggestionsResponse([], timedelta(seconds=10))])
+            MetricsAnalyzer([Scenario([])], [[SuggestionsResponse([], timedelta(seconds=10))]])
 
     def test_constructor_with_no_suggestions_responses(self):
         with self.assertRaises(NoSuggestionsResponsesException):
             MetricsAnalyzer(self._scenarios, [])
 
     def test_constructor_with_invalid_response_timestamp(self):
-        invalid_timestamp_suggestions_responses = [
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=-666)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0)),
-            SuggestionsResponse([], timedelta(seconds=0))
+        invalid_timestamp_suggestions_responses_for_each_scenario = [
+            [
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0))
+            ],
+            [
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=-666)),
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0)),
+                SuggestionsResponse([], timedelta(seconds=0))
+            ]
         ]
         with self.assertRaises(InvalidTimestampException):
-            MetricsAnalyzer(self._scenarios, invalid_timestamp_suggestions_responses)
+            MetricsAnalyzer(self._scenarios, invalid_timestamp_suggestions_responses_for_each_scenario)
 
     def test_constructor_with_no_suggestions_response_for_every_request(self):
         with self.assertRaises(NoSuggestionsResponsesForEveryRequestsException):
-            MetricsAnalyzer(self._scenarios, [SuggestionsResponse([], timedelta(seconds=10))])
+            MetricsAnalyzer(self._scenarios, [[SuggestionsResponse([], timedelta(seconds=10))]])
 
     def test_average_system_response_time(self):
         actual = self._metrics_analyzer.calculate_average_system_response_time()
@@ -136,16 +148,20 @@ class TestMetricsAnalyzer(unittest.TestCase):
         self.assertEquals(0, self._no_suggestions_responses_metrics_analyzer.calculate_number_of_suggested_questions())
 
     def test_number_of_suggested_questions_when_not_all_questions_updated(self):
-        suggestions_responses = [
-            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=49)),
-            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=49)),
-            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=54)),
-            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
+        suggestions_responses_for_each_scenario = [
+            [
+                SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=49)),
+                SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=49))
+            ],
+            [
+                SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=54)),
+                SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(self._suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(self._suggestions_3_questions, timedelta(seconds=48))
+            ]
         ]
-        metrics_analyzer = MetricsAnalyzer(self._scenarios, suggestions_responses)
+        metrics_analyzer = MetricsAnalyzer(self._scenarios, suggestions_responses_for_each_scenario)
         self.assertEquals(6, metrics_analyzer.calculate_number_of_suggested_questions())
 
     def test_number_of_suggested_links(self):

--- a/test/test_quality_indexes_analyzer.py
+++ b/test/test_quality_indexes_analyzer.py
@@ -6,25 +6,18 @@ from whisper_automatic_test.quality_indexes_analyzer import QualityIndexesAnalyz
 
 
 class TestQualityIndexesAnalyzer(unittest.TestCase):
-    _mock_metrics_analyzer = None
-    _quality_indexes_analyzer = None
-
     def setUp(self):
-        self._mock_metrics_analyzer = Mock()
-        self._quality_indexes_analyzer = QualityIndexesAnalyzer(self._mock_metrics_analyzer)
-
-        self._mock_metrics_analyzer.calculate_average_system_response_time.return_value = timedelta(seconds=10)
-        self._mock_metrics_analyzer.calculate_messages_number.return_value = 11
-        self._mock_metrics_analyzer.calculate_mean_position_of_selected_suggestions.return_value = 12
-        self._mock_metrics_analyzer.calculate_total_number_of_suggestions_updates.return_value = 13
-        self._mock_metrics_analyzer.calculate_number_of_unwanted_suggestions_updates.return_value = 14
-        self._mock_metrics_analyzer.calculate_number_of_selected_suggestions.return_value = 15
-        self._mock_metrics_analyzer.calculate_number_of_suggested_questions.return_value = 18
-        self._mock_metrics_analyzer.calculate_number_of_suggested_links.return_value = 19
-        self._mock_metrics_analyzer.calculate_mean_confidence_level_of_selected_suggestions.return_value = 20
+        self._quality_indexes_analyzer = _get_quality_indexes_analyzer_with_different_values_for_each_metric()
 
     def test_pertinence_index(self):
         self.assertAlmostEquals(-15, self._quality_indexes_analyzer.get_pertinence_index(), places=3)
+
+    def test_pertinence_index_with_zero_wanted_updates(self):
+        self.assertAlmostEquals(
+            float("-inf"),
+            _get_quality_indexes_analyzer_with_zero_wanted_updates().get_pertinence_index(),
+            places=3
+        )
 
     def test_speed_index(self):
         self.assertAlmostEquals(-2.333, self._quality_indexes_analyzer.get_speed_index(), places=3)
@@ -38,3 +31,33 @@ class TestQualityIndexesAnalyzer(unittest.TestCase):
 
     def test_confidence_index(self):
         self.assertAlmostEquals(20.000, self._quality_indexes_analyzer.get_confidence_index(), places=3)
+
+
+def _get_quality_indexes_analyzer_with_different_values_for_each_metric():
+    mock_metrics_analyzer = Mock()
+    quality_indexes_analyzer = QualityIndexesAnalyzer(mock_metrics_analyzer)
+    mock_metrics_analyzer.calculate_average_system_response_time.return_value = timedelta(seconds=10)
+    mock_metrics_analyzer.calculate_messages_number.return_value = 11
+    mock_metrics_analyzer.calculate_mean_position_of_selected_suggestions.return_value = 12
+    mock_metrics_analyzer.calculate_total_number_of_suggestions_updates.return_value = 13
+    mock_metrics_analyzer.calculate_number_of_unwanted_suggestions_updates.return_value = 14
+    mock_metrics_analyzer.calculate_number_of_selected_suggestions.return_value = 15
+    mock_metrics_analyzer.calculate_number_of_suggested_questions.return_value = 18
+    mock_metrics_analyzer.calculate_number_of_suggested_links.return_value = 19
+    mock_metrics_analyzer.calculate_mean_confidence_level_of_selected_suggestions.return_value = 20
+    return quality_indexes_analyzer
+
+
+def _get_quality_indexes_analyzer_with_zero_wanted_updates():
+    mock_metrics_analyzer = Mock()
+    quality_indexes_analyzer = QualityIndexesAnalyzer(mock_metrics_analyzer)
+    mock_metrics_analyzer.calculate_average_system_response_time.return_value = timedelta(seconds=10)
+    mock_metrics_analyzer.calculate_messages_number.return_value = 11
+    mock_metrics_analyzer.calculate_mean_position_of_selected_suggestions.return_value = 12
+    mock_metrics_analyzer.calculate_total_number_of_suggestions_updates.return_value = 666
+    mock_metrics_analyzer.calculate_number_of_unwanted_suggestions_updates.return_value = 666
+    mock_metrics_analyzer.calculate_number_of_selected_suggestions.return_value = 15
+    mock_metrics_analyzer.calculate_number_of_suggested_questions.return_value = 18
+    mock_metrics_analyzer.calculate_number_of_suggested_links.return_value = 19
+    mock_metrics_analyzer.calculate_mean_confidence_level_of_selected_suggestions.return_value = 20
+    return quality_indexes_analyzer

--- a/test/test_scenarios_runner.py
+++ b/test/test_scenarios_runner.py
@@ -45,11 +45,17 @@ class TestScenariosRunner(unittest.TestCase):
         self._scenario_runner = ScenariosRunner(self._mock_get_suggestions, self._mock_get_time)
 
     def test_run_scenarios(self):
-        suggestions_responses = self._scenario_runner.run(self._scenarios)
-        self.assertEquals(3, len(suggestions_responses))
-        suggestions_reponse_a = suggestions_responses[0]
-        suggestions_reponse_b = suggestions_responses[1]
-        suggestions_reponse_c = suggestions_responses[2]
+        suggestions_responses_of_each_scenario = self._scenario_runner.run(self._scenarios)
+        self.assertEquals(2, len(suggestions_responses_of_each_scenario))
+
+        suggestions_responses_of_scenario_a = suggestions_responses_of_each_scenario[0]
+        suggestions_responses_of_scenario_b = suggestions_responses_of_each_scenario[1]
+        self.assertEquals(2, len(suggestions_responses_of_scenario_a))
+        self.assertEquals(1, len(suggestions_responses_of_scenario_b))
+
+        suggestions_reponse_a = suggestions_responses_of_scenario_a[0]
+        suggestions_reponse_b = suggestions_responses_of_scenario_a[1]
+        suggestions_reponse_c = suggestions_responses_of_scenario_b[0]
 
         suggestions_a = suggestions_reponse_a.get_suggestions()
         self.assertEquals(2, len(suggestions_a))

--- a/test/test_suggestions_responses_analyzer.py
+++ b/test/test_suggestions_responses_analyzer.py
@@ -14,6 +14,7 @@ from whisper_automatic_test.suggestions_responses_analyzer import SuggestionsRes
 from whisper_automatic_test.whisper_api_adapter import whisper_response_to_suggestions
 
 SCENARIO_FILE_PATH = 'test/resources/test_scenarios_for_suggestions_responses_analyzer.csv'
+SCENARIOS_STARTING_WITH_SAME_FILE_PATH = 'test/resources/test_scenarios_second_scenario_starts_with_same.csv'
 EXAMPLE_WHISPER_RESPONSE_FILE_PATH = 'test/resources/example_whisper_response_3_links.json'
 EXAMPLE_WHISPER_RESPONSE_QUESTIONS_FILE_PATH = 'test/resources/example_whisper_response_3_questions.json'
 
@@ -26,38 +27,59 @@ def get_suggestions(file_path):
 class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
     def setUp(self):
         self._scenarios = get_scenarios_from_csv_file(SCENARIO_FILE_PATH)
+        self._scenarios_starting_with_same = get_scenarios_from_csv_file(SCENARIOS_STARTING_WITH_SAME_FILE_PATH)
+
         suggestions_3_links = whisper_response_to_suggestions(get_suggestions(EXAMPLE_WHISPER_RESPONSE_FILE_PATH))
         suggestions_3_questions = whisper_response_to_suggestions(
             get_suggestions(EXAMPLE_WHISPER_RESPONSE_QUESTIONS_FILE_PATH)
         )
         suggestions_2_last_links = suggestions_3_links[1:]
-        self._suggestions_responses = [
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=49)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=54)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_2_last_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
-            SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+        self._suggestions_responses_for_each_scenario = [
+            [
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=49))
+            ],
+            [
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=49)),
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=54)),
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_2_last_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48))
+            ],
+            [
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=48)),
+                SuggestionsResponse(suggestions_3_questions, timedelta(seconds=48))
+            ]
+        ]
+
+        self._suggestions_responses_starting_with_same = [
+            [
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=49))
+            ],
+            [
+                SuggestionsResponse([], timedelta(seconds=49)),
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=49))
+            ],
+            [
+                SuggestionsResponse(suggestions_3_links, timedelta(seconds=49))
+            ]
         ]
 
     def test_constructor_with_no_request_in_scenarios(self):
         with self.assertRaises(NoRequestsException):
-            SuggestionsResponsesAnalyzer([Scenario([])], self._suggestions_responses)
+            SuggestionsResponsesAnalyzer([Scenario([])], self._suggestions_responses_for_each_scenario)
 
     def test_constructor_with_no_suggestions_responses(self):
         with self.assertRaises(NoSuggestionsResponsesException):
@@ -66,6 +88,19 @@ class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
     def test_constructor_with_no_suggestions_response_for_every_request(self):
         with self.assertRaises(NoSuggestionsResponsesForEveryRequestsException):
             SuggestionsResponsesAnalyzer(self._scenarios, [SuggestionsResponse([], timedelta(seconds=10))])
+        with self.assertRaises(NoSuggestionsResponsesForEveryRequestsException):
+            suggestions_responses_for_each_scenario_but_not_good_size = [
+                [
+                    SuggestionsResponse([], timedelta(seconds=10))
+                ],
+                [
+                    SuggestionsResponse([], timedelta(seconds=10))
+                ],
+                [
+                    SuggestionsResponse([], timedelta(seconds=10))
+                ],
+            ]
+            SuggestionsResponsesAnalyzer(self._scenarios, suggestions_responses_for_each_scenario_but_not_good_size)
 
     def test_analyze_with_one_successful_suggestions_response(self):
         expected_analysis = ['success(1-1)']
@@ -73,8 +108,8 @@ class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
         suggestion = Suggestion('link', 'https://www.coveo.com/')
         suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(
             [Scenario([request])],
-            [SuggestionsResponse([suggestion], timedelta(seconds=0))])
-        self.assertEquals(expected_analysis, suggestions_responses_analyzer.analyze())
+            [[SuggestionsResponse([suggestion], timedelta(seconds=0))]])
+        self.assertEquals(expected_analysis, suggestions_responses_analyzer.analyze_scenarios())
 
     def test_analyze(self):
         expected_analysis = [
@@ -100,11 +135,17 @@ class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
             'success',
             'fail'
         ]
-        suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(self._scenarios, self._suggestions_responses)
-        self.assertEquals(expected_analysis, suggestions_responses_analyzer.analyze())
+        suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(
+            self._scenarios,
+            self._suggestions_responses_for_each_scenario
+        )
+        self.assertEquals(expected_analysis, suggestions_responses_analyzer.analyze_scenarios())
 
     def test_analyze_to_string(self):
-        suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(self._scenarios, self._suggestions_responses)
+        suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(
+            self._scenarios,
+            self._suggestions_responses_for_each_scenario
+        )
         expected_analysis_string = \
             ('Scenario,Person,Message,Success condition,Result,System response time\n'
              '1,agent,I love mushrooms,same,fail,0:00:49\n'
@@ -129,5 +170,20 @@ class TestSuggestionsResponsesAnalyzer(unittest.TestCase):
              '3,asker,Hello,link,success,0:00:48\n'
              '3,asker,Hello,link,fail,0:00:48\n'
              '\n8 of 21 tests passed')
+        analysis_string = suggestions_responses_analyzer.analyze_to_string()
+        self.assertEquals(expected_analysis_string, analysis_string)
+
+    def test_same_at_start_of_scenario(self):
+        expected_analysis_string = \
+            ('Scenario,Person,Message,Success condition,Result,System response time\n'
+             '1,agent,link required, should pass,link,success(1-1),0:00:49\n'
+             '2,asker,same required, expects empty because start of scenario, should pass,same,success,0:00:49\n'
+             '2,agent,link required, should pass,link,success(1-1),0:00:49\n'
+             '3,asker,same required, expects empty because start of scenario, should fail,same,fail,0:00:49\n'
+             '\n3 of 4 tests passed')
+        suggestions_responses_analyzer = SuggestionsResponsesAnalyzer(
+            self._scenarios_starting_with_same,
+            self._suggestions_responses_starting_with_same
+        )
         analysis_string = suggestions_responses_analyzer.analyze_to_string()
         self.assertEquals(expected_analysis_string, analysis_string)

--- a/whisper_automatic_test/quality_indexes_analyzer.py
+++ b/whisper_automatic_test/quality_indexes_analyzer.py
@@ -14,6 +14,8 @@ class QualityIndexesAnalyzer:
             self._metrics_analyzer.calculate_total_number_of_suggestions_updates() -
             self._metrics_analyzer.calculate_number_of_unwanted_suggestions_updates()
         )
+        if 0 == number_of_wanted_suggestions_updates:
+            return float('-inf')
         return (
                 self._metrics_analyzer.calculate_number_of_selected_suggestions() /
                 number_of_wanted_suggestions_updates

--- a/whisper_automatic_test/scenarios_runner.py
+++ b/whisper_automatic_test/scenarios_runner.py
@@ -17,8 +17,7 @@ class ScenariosRunner:
             self._get_suggestions_responses_of_scenario(scenario_chatkey_pair[0], scenario_chatkey_pair[1])
             for scenario_chatkey_pair in scenario_chatkey_pairs
         ]
-        suggestions_responses_independent_of_the_scenario = sum(suggestions_responses_of_each_scenario, [])
-        return suggestions_responses_independent_of_the_scenario
+        return suggestions_responses_of_each_scenario
 
     def _get_suggestions_response_of_request(self, request, chatkey):
         before_datetime = self._get_time()

--- a/whisper_automatic_test/suggestions_responses_analyzer.py
+++ b/whisper_automatic_test/suggestions_responses_analyzer.py
@@ -69,57 +69,74 @@ def analyse_notlink_with_request_data(request, current_suggestions):
     return 0 == len(forbidden_suggested_links)
 
 
+def get_requests(scenarios):
+    requests = []
+    for scenario in scenarios:
+        requests += scenario.get_requests()
+    return requests
+
+
+def analyze_scenario(scenario, suggestions_responses_for_current_scenario):
+    analysis = []
+    previous_suggestions = []
+    for i, request in enumerate(scenario.get_requests()):
+        suggestions_reponse_of_request = suggestions_responses_for_current_scenario[i]
+        suggestions_for_request = suggestions_reponse_of_request.get_suggestions()
+        is_success = analyse_same(request, suggestions_for_request, previous_suggestions)
+        is_success |= analyse_link_or_question_without_request_data(request, suggestions_for_request)
+        is_success |= analyse_notlink_with_request_data(request, suggestions_for_request)
+        if is_success:
+            analysis.append('success')
+        else:
+            selected_suggestion_position = analyse_link_or_question_with_request_data(request, suggestions_for_request)
+            analysis.append('success(' + selected_suggestion_position + ')') if selected_suggestion_position \
+                else analysis.append('fail')
+        previous_suggestions = suggestions_for_request
+    return analysis
+
+
 class SuggestionsResponsesAnalyzer:
     def __init__(self, scenarios, suggestions_responses):
         self._scenarios = scenarios
-        self._requests = []
-        for scenario in scenarios:
-            self._requests += scenario.get_requests()
-        self._suggestions_responses = suggestions_responses
+        self._suggestions_responses_for_each_scenario = suggestions_responses
         self.raise_if_there_is_no_request_in_scenarios()
         self.raise_if_there_is_no_suggestions_responses()
         self.raise_if_there_is_not_a_suggestions_response_for_every_request()
 
     def raise_if_there_is_no_request_in_scenarios(self):
-        if not self._requests:
+        if not get_requests(self._scenarios):
             raise NoRequestsException('No requests')
 
     def raise_if_there_is_no_suggestions_responses(self):
-        if not self._suggestions_responses:
+        if not self._suggestions_responses_for_each_scenario:
             raise NoSuggestionsResponsesException('No suggestions responses to analyze')
 
     def raise_if_there_is_not_a_suggestions_response_for_every_request(self):
-        if len(self._requests) != len(self._suggestions_responses):
-            raise NoSuggestionsResponsesForEveryRequestsException(
-                'There is not a suggestions response for every request')
+        no_suggestions_responses_for_every_request_exception = NoSuggestionsResponsesForEveryRequestsException(
+            'There is not a suggestions response for every request')
+        if len(self._scenarios) != len(self._suggestions_responses_for_each_scenario):
+            raise no_suggestions_responses_for_every_request_exception
+        for i, scenario in enumerate(self._scenarios):
+            suggestions_responses_for_scenario = self._suggestions_responses_for_each_scenario[i]
+            if len(scenario.get_requests()) != len(suggestions_responses_for_scenario):
+                raise no_suggestions_responses_for_every_request_exception
 
-    def analyze(self):
+    def analyze_scenarios(self):
         analysis = []
-        previous_suggestions = []
-        for i, request in enumerate(self._requests):
-            current_suggestions = self._suggestions_responses[i].get_suggestions()
-            is_success = analyse_same(request, current_suggestions, previous_suggestions)
-            is_success |= analyse_link_or_question_without_request_data(request, current_suggestions)
-            is_success |= analyse_notlink_with_request_data(request, current_suggestions)
-            if is_success:
-                analysis.append('success')
-            else:
-                selected_suggestion_position = analyse_link_or_question_with_request_data(request, current_suggestions)
-                analysis.append('success(' + selected_suggestion_position + ')') if selected_suggestion_position \
-                    else analysis.append('fail')
-            previous_suggestions = current_suggestions
+        for i, scenario in enumerate(self._scenarios):
+            suggestions_responses_for_current_scenario = self._suggestions_responses_for_each_scenario[i]
+            for scenario_analysis in analyze_scenario(scenario, suggestions_responses_for_current_scenario):
+                analysis.append(scenario_analysis)
         return analysis
 
     def analyze_to_string(self):
-        analysis = self.analyze()
-        number_of_successful_analysis = 0
-        for single_analysis in analysis:
-            if 'success' in single_analysis:
-                number_of_successful_analysis += 1
+        analysis = self.analyze_scenarios()
+        number_of_successful_analysis = sum(['success' in single_analysis for single_analysis in analysis])
         analysis_position = 0
         analysis_string = 'Scenario,Person,Message,Success condition,Result,System response time\n'
         for i, scenario in enumerate(self._scenarios):
-            for request in scenario.get_requests():
+            suggestions_responses_scenario = self._suggestions_responses_for_each_scenario[i]
+            for j, request in enumerate(scenario.get_requests()):
                 scenario_id = str(i + 1)
                 elements = [
                     scenario_id,
@@ -127,10 +144,10 @@ class SuggestionsResponsesAnalyzer:
                     request.get_message(),
                     request.get_success_condition(),
                     analysis[analysis_position],
-                    str(self._suggestions_responses[analysis_position].get_response_time_duration())
+                    str(suggestions_responses_scenario[j].get_response_time_duration())
                 ]
                 analysis_string += ','.join(elements) + '\n'
                 analysis_position += 1
         analysis_string += '\n' + str(number_of_successful_analysis) + ' of ' \
-                           + str(len(self._requests)) + ' tests passed'
+                           + str(len(get_requests(self._scenarios))) + ' tests passed'
         return analysis_string

--- a/whisper_automatic_test/suggestions_responses_analyzer.py
+++ b/whisper_automatic_test/suggestions_responses_analyzer.py
@@ -2,6 +2,9 @@ from whisper_automatic_test.exceptions.no_requests_exception import NoRequestsEx
 from whisper_automatic_test.exceptions.no_suggestions_responses_exception import NoSuggestionsResponsesException
 from whisper_automatic_test.exceptions.no_suggestions_responses_for_every_requests_exception \
     import NoSuggestionsResponsesForEveryRequestsException
+from whisper_automatic_test.utility import raise_if_there_is_no_request_in_scenarios, \
+    raise_if_there_is_no_suggestions_responses, raise_if_there_is_not_a_suggestions_response_for_every_request, \
+    get_requests
 
 
 def get_selected_suggestion(suggestions, data_to_find_in_suggestions):
@@ -69,13 +72,6 @@ def analyse_notlink_with_request_data(request, current_suggestions):
     return 0 == len(forbidden_suggested_links)
 
 
-def get_requests(scenarios):
-    requests = []
-    for scenario in scenarios:
-        requests += scenario.get_requests()
-    return requests
-
-
 def analyze_scenario(scenario, suggestions_responses_for_current_scenario):
     analysis = []
     previous_suggestions = []
@@ -96,12 +92,15 @@ def analyze_scenario(scenario, suggestions_responses_for_current_scenario):
 
 
 class SuggestionsResponsesAnalyzer:
-    def __init__(self, scenarios, suggestions_responses):
+    def __init__(self, scenarios, suggestions_responses_for_each_scenario):
         self._scenarios = scenarios
-        self._suggestions_responses_for_each_scenario = suggestions_responses
-        self.raise_if_there_is_no_request_in_scenarios()
-        self.raise_if_there_is_no_suggestions_responses()
-        self.raise_if_there_is_not_a_suggestions_response_for_every_request()
+        self._suggestions_responses_for_each_scenario = suggestions_responses_for_each_scenario
+        raise_if_there_is_no_request_in_scenarios(scenarios)
+        raise_if_there_is_no_suggestions_responses(suggestions_responses_for_each_scenario)
+        raise_if_there_is_not_a_suggestions_response_for_every_request(
+            scenarios,
+            suggestions_responses_for_each_scenario
+        )
 
     def raise_if_there_is_no_request_in_scenarios(self):
         if not get_requests(self._scenarios):

--- a/whisper_automatic_test/utility.py
+++ b/whisper_automatic_test/utility.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+
+from whisper_automatic_test.exceptions.invalid_timestamp_exception import InvalidTimestampException
+from whisper_automatic_test.exceptions.no_requests_exception import NoRequestsException
+from whisper_automatic_test.exceptions.no_suggestions_responses_exception import NoSuggestionsResponsesException
+from whisper_automatic_test.exceptions.no_suggestions_responses_for_every_requests_exception import \
+    NoSuggestionsResponsesForEveryRequestsException
+
+
+def raise_if_there_is_no_request_in_scenarios(scenarios):
+    if not get_requests(scenarios):
+        raise NoRequestsException('No requests')
+
+
+def raise_if_there_is_no_suggestions_responses(suggestions_responses_for_each_scenario):
+    if not suggestions_responses_for_each_scenario:
+        raise NoSuggestionsResponsesException('No suggestions responses to analyze')
+
+
+def raise_if_there_is_not_a_suggestions_response_for_every_request(scenarios, suggestions_responses_for_each_scenario):
+    no_suggestions_responses_for_every_request_exception = NoSuggestionsResponsesForEveryRequestsException(
+        'There is not a suggestions response for every request')
+    if len(scenarios) != len(suggestions_responses_for_each_scenario):
+        raise no_suggestions_responses_for_every_request_exception
+    for i, scenario in enumerate(scenarios):
+        suggestions_responses_for_scenario = suggestions_responses_for_each_scenario[i]
+        if len(scenario.get_requests()) != len(suggestions_responses_for_scenario):
+            raise no_suggestions_responses_for_every_request_exception
+
+
+def raise_if_there_is_an_invalid_timestamp(suggestions_responses_for_each_scenario):
+    for suggestions_responses_for_a_scenario in suggestions_responses_for_each_scenario:
+        for suggestion_response in suggestions_responses_for_a_scenario:
+            is_valid_timestamp = suggestion_response.get_response_time_duration() >= timedelta(seconds=0)
+            if not is_valid_timestamp:
+                raise InvalidTimestampException(
+                    'Received timestamp of response should not be smaller than sent timestamp')
+
+
+def get_requests(scenarios):
+    requests = []
+    for scenario in scenarios:
+        requests += scenario.get_requests()
+    return requests


### PR DESCRIPTION
Success condition 'same' would fail when empty suggestions were returned for the first request of a scenario if the last request of the previous scenario returned different suggestions.

Now the suggestions responses are separated by scenario. So if the first returned suggestions are empty, 'same' will count as successful independently of the previous scenario.